### PR TITLE
Adds error handling for ditto init

### DIFF
--- a/SwiftUI/Edge Debug Helper.xcodeproj/project.pbxproj
+++ b/SwiftUI/Edge Debug Helper.xcodeproj/project.pbxproj
@@ -605,7 +605,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
-				MARKETING_VERSION = 0.2.0;
+				MARKETING_VERSION = 0.2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.costoda.dittoedgestudio;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -661,7 +661,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
-				MARKETING_VERSION = 0.2.0;
+				MARKETING_VERSION = 0.2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.costoda.dittoedgestudio;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/SwiftUI/Edge Debug Helper.xcodeproj/project.pbxproj
+++ b/SwiftUI/Edge Debug Helper.xcodeproj/project.pbxproj
@@ -612,6 +612,7 @@
 				SDKROOT = auto;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx xros xrsimulator";
 				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_OBJC_BRIDGING_HEADER = "Edge Debug Helper/Edge-Debug-Helper-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2,7";
 				XROS_DEPLOYMENT_TARGET = 2.0;
@@ -668,6 +669,7 @@
 				SDKROOT = auto;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx xros xrsimulator";
 				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_OBJC_BRIDGING_HEADER = "Edge Debug Helper/Edge-Debug-Helper-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2,7";
 				XROS_DEPLOYMENT_TARGET = 2.0;

--- a/SwiftUI/Edge Debug Helper/Data/DittoManager.swift
+++ b/SwiftUI/Edge Debug Helper/Data/DittoManager.swift
@@ -182,9 +182,6 @@ actor DittoManager {
             }
             
             // Validate that appId is a valid UUID
-            // guard UUID(uuidString: appConfig.appId) != nil else {
-            //     throw AppError.error(message: "Invalid App ID format. The App ID must be a valid UUID (e.g., 550e8400-e29b-41d4-a716-446655440000)")
-            // }
             
             //https://docs.ditto.live/sdk/latest/install-guides/swift#integrating-and-initializing-sync
             // Pre-validate based on identity type to avoid NSException

--- a/SwiftUI/Edge Debug Helper/Data/DittoManager.swift
+++ b/SwiftUI/Edge Debug Helper/Data/DittoManager.swift
@@ -60,7 +60,7 @@ actor DittoManager {
                     for: .applicationSupportDirectory,
                     in: .userDomainMask
                 )[0]
-                .appendingPathComponent("ditto_local_config")
+                .appendingPathComponent("ditto_appconfig")
 
                 // Ensure directory exists
                 if !FileManager.default.fileExists(

--- a/SwiftUI/Edge Debug Helper/Ditto_Edge_StudioApp.swift
+++ b/SwiftUI/Edge Debug Helper/Ditto_Edge_StudioApp.swift
@@ -39,7 +39,7 @@ struct Ditto_Edge_StudioApp: App {
                 }
                 .environmentObject(appState)
         }
-        .windowResizability(.contentSize)
+        .windowResizability(.contentMinSize)
                 .handlesExternalEvents(matching: Set(arrayLiteral: "*"))
                 .commands {
                     CommandGroup(replacing: .newItem) {

--- a/SwiftUI/Edge Debug Helper/Edge-Debug-Helper-Bridging-Header.h
+++ b/SwiftUI/Edge Debug Helper/Edge-Debug-Helper-Bridging-Header.h
@@ -1,0 +1,8 @@
+//
+//  Edge-Debug-Helper-Bridging-Header.h
+//  Edge Debug Helper
+//
+//  Bridging header for Objective-C exception handling
+//
+
+#import "ExceptionCatcher.h"

--- a/SwiftUI/Edge Debug Helper/ExceptionCatcher.h
+++ b/SwiftUI/Edge Debug Helper/ExceptionCatcher.h
@@ -1,0 +1,12 @@
+//
+//  ExceptionCatcher.h
+//  Edge Debug Helper
+//
+
+#import <Foundation/Foundation.h>
+
+@interface ExceptionCatcher : NSObject
+
++ (NSError *)performBlock:(void (^)(void))block;
+
+@end

--- a/SwiftUI/Edge Debug Helper/ExceptionCatcher.m
+++ b/SwiftUI/Edge Debug Helper/ExceptionCatcher.m
@@ -1,0 +1,29 @@
+//
+//  ExceptionCatcher.m
+//  Edge Debug Helper
+//
+
+#import "ExceptionCatcher.h"
+
+@implementation ExceptionCatcher
+
++ (NSError *)performBlock:(void (^)(void))block {
+    @try {
+        if (block) {
+            block();
+        }
+        return nil;
+    }
+    @catch (NSException *exception) {
+        return [NSError errorWithDomain:@"DittoExceptionError"
+                                   code:1001
+                               userInfo:@{
+                                   NSLocalizedDescriptionKey: exception.reason ?: @"Unknown exception",
+                                   NSLocalizedFailureReasonErrorKey: exception.name ?: @"NSException",
+                                   @"ExceptionName": exception.name ?: @"",
+                                   @"ExceptionReason": exception.reason ?: @""
+                               }];
+    }
+}
+
+@end

--- a/SwiftUI/Edge Debug Helper/NSExceptionHandler.c
+++ b/SwiftUI/Edge Debug Helper/NSExceptionHandler.c
@@ -1,0 +1,44 @@
+//
+//  NSExceptionHandler.c
+//  Edge Debug Helper
+//
+//  C-based NSException handler for catching Objective-C exceptions
+//
+
+#include <stdio.h>
+#include <objc/objc-exception.h>
+#include <setjmp.h>
+#include "NSExceptionHandler.h"
+
+static jmp_buf exception_buf;
+static int exception_caught = 0;
+
+// Exception handler function
+static void exception_handler(id exception, void *context) {
+    exception_caught = 1;
+    longjmp(exception_buf, 1);
+}
+
+int try_objective_c_block(void (^block)(void)) {
+    exception_caught = 0;
+    
+    // Set up the exception handler
+    void *token = objc_addExceptionHandler(exception_handler, NULL);
+    
+    // Set up the jump buffer
+    if (setjmp(exception_buf) == 0) {
+        // Execute the block
+        if (block) {
+            block();
+        }
+        
+        // Clear the exception handler
+        objc_removeExceptionHandler(token);
+        return 0; // Success, no exception
+    } else {
+        // We jumped here due to an exception
+        // Clear the exception handler
+        objc_removeExceptionHandler(token);
+        return 1; // Exception caught
+    }
+}

--- a/SwiftUI/Edge Debug Helper/NSExceptionHandler.h
+++ b/SwiftUI/Edge Debug Helper/NSExceptionHandler.h
@@ -1,0 +1,24 @@
+//
+//  NSExceptionHandler.h
+//  Edge Debug Helper
+//
+//  C-based NSException handler for catching Objective-C exceptions
+//
+
+#ifndef NSExceptionHandler_h
+#define NSExceptionHandler_h
+
+#import <objc/objc.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Returns 0 if no exception, 1 if exception was caught
+int try_objective_c_block(void (^block)(void));
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* NSExceptionHandler_h */

--- a/SwiftUI/Edge Debug Helper/Views/AppEditorView.swift
+++ b/SwiftUI/Edge Debug Helper/Views/AppEditorView.swift
@@ -26,6 +26,7 @@ struct AppEditorView: View {
                                     .pickerStyle(.segmented)
                 Section("Basic Information") {
                     TextField("Name", text: $viewModel.name)
+                        .lineLimit(1)
                         .padding(.bottom, 10)
                 }
 
@@ -33,6 +34,7 @@ struct AppEditorView: View {
                     TextField("App ID", text: $viewModel.appId)
                         .textFieldStyle(.roundedBorder)
                         .font(.system(.body, design: .monospaced))
+                        .lineLimit(1)
                         // Auto-trim whitespace when pasting content
                         .onPasteCommand(of: [.plainText]) { providers in
                             for provider in providers {
@@ -47,9 +49,9 @@ struct AppEditorView: View {
                         }
                         .padding(.bottom, 5)
                     
-                    TextField("Playground Token", text: $viewModel.authToken, axis: .vertical)
-                        .lineLimit(1...3)
+                    TextField("Playground Token", text: $viewModel.authToken)
                         .textFieldStyle(.roundedBorder)
+                        .lineLimit(1)
                         // Auto-trim whitespace when pasting token content
                         .onPasteCommand(of: [.plainText]) { providers in
                             for provider in providers {
@@ -67,25 +69,25 @@ struct AppEditorView: View {
 
                 if (viewModel.mode == "online") {
                     Section("Ditto Server (BigPeer) Information") {
-                        TextField("Auth URL", text: $viewModel.authUrl, axis: .vertical)
-                            .lineLimit(1...2)
+                        TextField("Auth URL", text: $viewModel.authUrl)
                             .textFieldStyle(.roundedBorder)
+                            .lineLimit(1)
                         
-                        TextField("Websocket URL", text: $viewModel.websocketUrl, axis: .vertical)
-                            .lineLimit(1...2)
+                        TextField("Websocket URL", text: $viewModel.websocketUrl)
                             .textFieldStyle(.roundedBorder)
+                            .lineLimit(1)
                             .padding(.bottom, 10)
                     }
                     Section("Ditto Server - HTTP API - Optional") {
                         VStack(alignment: .leading) {
-                            TextField("HTTP API URL", text: $viewModel.httpApiUrl, axis: .vertical)
-                                .lineLimit(1...3)
+                            TextField("HTTP API URL", text: $viewModel.httpApiUrl)
                                 .textFieldStyle(.roundedBorder)
+                                .lineLimit(1)
                                 .padding(.bottom, 8)
                             
-                            TextField("HTTP API Key", text: $viewModel.httpApiKey, axis: .vertical)
-                                .lineLimit(1...3)
+                            TextField("HTTP API Key", text: $viewModel.httpApiKey)
                                 .textFieldStyle(.roundedBorder)
+                                .lineLimit(1)
                                 .padding(.bottom, 10)
                             
                             Toggle("Allow untrusted certificates", isOn: $viewModel.allowUntrustedCerts)
@@ -119,11 +121,7 @@ struct AppEditorView: View {
                 ToolbarItem(placement: .confirmationAction){
                     Button ("Save"){
                         Task {
-                            do {
-                                try await viewModel.save(appState: appState)
-                            } catch {
-                                //the view model handles this
-                            }
+                            await viewModel.save(appState: appState)
                             isPresented = false
                         }
                     }
@@ -178,7 +176,7 @@ extension AppEditorView {
             }
         }
         
-        func save(appState: AppState) async throws {
+        func save(appState: AppState) async {
             do {
                 // Trim whitespace from appId
                 let trimmedAppId = appId.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -200,7 +198,6 @@ extension AppEditorView {
                 }
             } catch {
                 appState.setError(error)
-                throw error
             }
         }
     }

--- a/SwiftUI/Edge Debug Helper/Views/AppEditorView.swift
+++ b/SwiftUI/Edge Debug Helper/Views/AppEditorView.swift
@@ -30,33 +30,22 @@ struct AppEditorView: View {
                 }
 
                 Section("Authorization Information") {
-                    VStack(alignment: .leading, spacing: 4) {
-                        TextField("App ID", text: $viewModel.appId)
-                            .textFieldStyle(.roundedBorder)
-                            .font(.system(.body, design: .monospaced))
-                            // Auto-trim whitespace when pasting content (common when copying UUIDs from docs)
-                            .onPasteCommand(of: [.plainText]) { providers in
-                                for provider in providers {
-                                    _ = provider.loadObject(ofClass: NSString.self) { string, error in
-                                        if let string = string as? String {
-                                            DispatchQueue.main.async {
-                                                viewModel.appId = string.trimmingCharacters(in: .whitespacesAndNewlines)
-                                            }
+                    TextField("App ID", text: $viewModel.appId)
+                        .textFieldStyle(.roundedBorder)
+                        .font(.system(.body, design: .monospaced))
+                        // Auto-trim whitespace when pasting content
+                        .onPasteCommand(of: [.plainText]) { providers in
+                            for provider in providers {
+                                _ = provider.loadObject(ofClass: NSString.self) { string, error in
+                                    if let string = string as? String {
+                                        DispatchQueue.main.async {
+                                            viewModel.appId = string.trimmingCharacters(in: .whitespacesAndNewlines)
                                         }
                                     }
                                 }
                             }
-                        if !viewModel.appId.isEmpty && UUID(uuidString: viewModel.appId.trimmingCharacters(in: .whitespacesAndNewlines)) == nil {
-                            Text("App ID must be a valid UUID format (36 characters)")
-                                .font(.caption)
-                                .foregroundColor(.red)
-                        } else {
-                            Text("Enter a valid UUID (e.g., 550e8400-e29b-41d4-a716-446655440000)")
-                                .font(.caption)
-                                .foregroundColor(.secondary)
                         }
-                    }
-                    .padding(.bottom, 5)
+                        .padding(.bottom, 5)
                     
                     TextField("Playground Token", text: $viewModel.authToken, axis: .vertical)
                         .lineLimit(1...3)
@@ -193,11 +182,6 @@ extension AppEditorView {
             do {
                 // Trim whitespace from appId
                 let trimmedAppId = appId.trimmingCharacters(in: .whitespacesAndNewlines)
-                
-                // Validate that appId is a valid UUID before saving
-                guard UUID(uuidString: trimmedAppId) != nil else {
-                    throw AppError.error(message: "Invalid App ID format. The App ID must be a valid UUID (e.g., 550e8400-e29b-41d4-a716-446655440000)")
-                }
                 
                 let appConfig = DittoAppConfig(_id,
                                                name: name,

--- a/SwiftUI/Edge Debug Helper/Views/AppEditorView.swift
+++ b/SwiftUI/Edge Debug Helper/Views/AppEditorView.swift
@@ -142,7 +142,6 @@ struct AppEditorView: View {
                         viewModel.appId.isEmpty ||
                         viewModel.name.isEmpty ||
                         viewModel.authToken.isEmpty
-                        // || UUID(uuidString: viewModel.appId.trimmingCharacters(in: .whitespacesAndNewlines)) == nil
                     )
                 }
             }


### PR DESCRIPTION
This pull request introduces improved init error handling for Ditto app configuration, with some UX changes for pasting content into the config inputs. The changes also enhance the user interface for editing app configuration, providing clearer feedback and input handling.

**Validation and error handling improvements:**

* Wrapped Ditto initialization to catch errors and provide user-friendly error message when Ditto fails to init. [[1]](diffhunk://#diff-57133f3f9dc76bc6065bd11cc36d05196cbf5ccc752ebc36fed381ff5fde88e4R110-R122) [[2]](diffhunk://#diff-57133f3f9dc76bc6065bd11cc36d05196cbf5ccc752ebc36fed381ff5fde88e4R220-R232)

**User interface enhancements:**

* Improved the `AppEditorView` to auto-trim whitespace when pasting into `App ID` and `authToken` fields
* Replaced `TextEditor` components with multi-line `TextField`s for URLs and keys, improving consistency.

**Minor UI adjustment:**

* Changed window resizability from `.contentSize` to `.contentMinSize` for better window management.Allows the app window to be resized.

**Ditto Init Error handling**
* Adds an objective-c error transformation bridge which can catch NSExceptions and convert them to an Error format that Swift can understand. 
* Adds Ditto init error handling.