### PR TITLE
Adds sharedkey auth.

### DIFF
--- a/SwiftUI/Edge Debug Helper/AppState.swift
+++ b/SwiftUI/Edge Debug Helper/AppState.swift
@@ -49,7 +49,7 @@ class AppState: ObservableObject {
             websocketUrl: websocketUrl,
             httpApiUrl: httpApiUrl,
             httpApiKey: httpApiKey,
-            mode: "online",
+            mode: .onlinePlayground,
             allowUntrustedCerts: false
         )
     }

--- a/SwiftUI/Edge Debug Helper/Data/DittoManager.swift
+++ b/SwiftUI/Edge Debug Helper/Data/DittoManager.swift
@@ -87,13 +87,9 @@ actor DittoManager {
                 var dittoInstance: Ditto?
                 
                 let error = ExceptionCatcher.perform {
+                    let identity = self.createIdentity(from: appState.appConfig)
                     dittoInstance = Ditto(
-                        identity: .onlinePlayground(
-                            appID: appState.appConfig.appId,
-                            token: appState.appConfig.authToken,
-                            enableDittoCloudSync: false,
-                            customAuthURL: URL(string: appState.appConfig.authUrl)
-                        ),
+                        identity: identity,
                         persistenceDirectory: localDirectoryPath
                     )
                 }
@@ -105,6 +101,13 @@ actor DittoManager {
                 
                 guard let ditto = dittoInstance else {
                     throw AppError.error(message: "Failed to create Ditto instance")
+                }
+                
+                // For shared key mode, set the offline license token (using authToken field)
+                if appState.appConfig.mode == .sharedKey && !appState.appConfig.authToken.isEmpty {
+                    print("Setting offline license token: `\(appState.appConfig.authToken)`")
+                    try ditto.setOfflineOnlyLicenseToken(appState.appConfig.authToken)
+                    print("Successfully set offline license token")
                 }
                 
                 dittoLocal = ditto
@@ -175,13 +178,9 @@ actor DittoManager {
             var dittoInstance: Ditto?
             
             let error = ExceptionCatcher.perform {
+                let identity = self.createIdentity(from: appConfig)
                 dittoInstance = Ditto(
-                    identity: .onlinePlayground(
-                        appID: appConfig.appId,
-                        token: appConfig.authToken,
-                        enableDittoCloudSync: false,
-                        customAuthURL: URL(string: appConfig.authUrl)
-                    ),
+                    identity: identity,
                     persistenceDirectory: localDirectoryPath
                 )
             }
@@ -193,6 +192,11 @@ actor DittoManager {
             
             guard let ditto = dittoInstance else {
                 throw AppError.error(message: "Failed to create Ditto instance")
+            }
+            
+            // For shared key mode, set the offline license token (using authToken field)
+            if appConfig.mode == .sharedKey && !appConfig.authToken.isEmpty {
+                try ditto.setOfflineOnlyLicenseToken(appConfig.authToken)
             }
             
             dittoSelectedApp = ditto
@@ -250,6 +254,80 @@ actor DittoManager {
             await Task.detached(priority: .utility) {
                 ditto.sync.stop()
             }.value
+        }
+    }
+    
+    /// Shuts down all Ditto instances and cleans up resources
+    func shutdown() async {
+        // Stop and clean up selected app
+        await closeDittoSelectedApp()
+        
+        // Stop and clean up local Ditto instance
+        if let localDitto = dittoLocal {
+            await Task.detached(priority: .utility) {
+                localDitto.sync.stop()
+            }.value
+            dittoLocal = nil
+        }
+        
+        // Reset state
+        isStoreInitialized = false
+        appState = nil
+        dittoSelectedAppConfig = nil
+    }
+    
+    /// Creates the appropriate Ditto identity based on app configuration
+    private func createIdentity(from appConfig: DittoAppConfig) -> DittoIdentity {
+        switch appConfig.mode {
+        case .sharedKey:
+            // Log the offline license token and secret key for verification
+            print("Creating shared key identity:")
+            print("App ID: `\(appConfig.appId)`")
+            print("Offline License Token: `\(appConfig.authToken)`")
+            print("Secret Key: `\(appConfig.secretKey)`")
+            print("Secret Key isEmpty: \(appConfig.secretKey.isEmpty)")
+            
+            // Use shared key identity with optional secret key
+            // Note: The offline license token is set separately via setOfflineOnlyLicenseToken
+            if !appConfig.secretKey.isEmpty {
+                // If secret key is provided, use it for identity creation
+                print("Using shared key identity WITH secret key")
+                return .sharedKey(appID: appConfig.appId, sharedKey: appConfig.secretKey)
+            } else {
+                // No secret key, use basic offline playground identity
+                print("Using shared key identity WITHOUT secret key")
+                return .offlinePlayground(appID: appConfig.appId)
+            }
+            
+        case .offlinePlayground:
+            // Use online playground identity but simplified (authToken is the playground token here)
+            print("Creating offline playground identity:")
+            print("App ID: `\(appConfig.appId)`")
+            print("Playground Token: `\(appConfig.authToken)`")
+            
+            return .onlinePlayground(
+                appID: appConfig.appId,
+                token: appConfig.authToken,
+                enableDittoCloudSync: false,
+                customAuthURL: nil
+            )
+            
+        case .onlinePlayground:
+            // Use online playground identity (authToken is the playground token here)
+            print("Creating online identity:")
+            print("App ID: `\(appConfig.appId)`")
+            print("Playground Token: `\(appConfig.authToken)`")
+            print("Auth URL: `\(appConfig.authUrl)`")
+            
+            return .onlinePlayground(
+                appID: appConfig.appId,
+                token: appConfig.authToken,
+                enableDittoCloudSync: false,
+                customAuthURL: URL(string: appConfig.authUrl)
+            )
+            
+        default:
+            fatalError("Unknown mode: '\(appConfig.mode)'. Expected .onlinePlayground, .offlinePlayground, or .sharedKey")
         }
     }
 }

--- a/SwiftUI/Edge Debug Helper/Data/Repositories/DatabaseRepository.swift
+++ b/SwiftUI/Edge Debug Helper/Data/Repositories/DatabaseRepository.swift
@@ -41,6 +41,7 @@ actor DatabaseRepository {
                     "httpApiKey": appConfig.httpApiKey,
                     "mode": appConfig.mode,
                     "allowUntrustedCerts": appConfig.allowUntrustedCerts,
+                    "secretKey": appConfig.secretKey,
                 ]
             ]
             try await ditto.store.execute(
@@ -162,7 +163,7 @@ actor DatabaseRepository {
         
         do {
             let query =
-            "UPDATE dittoappconfigs SET name = :name, appId = :appId, authToken = :authToken, authUrl = :authUrl, websocketUrl = :websocketUrl, httpApiUrl = :httpApiUrl, httpApiKey = :httpApiKey, mode = :mode, allowUntrustedCerts = :allowUntrustedCerts WHERE _id = :_id"
+            "UPDATE dittoappconfigs SET name = :name, appId = :appId, authToken = :authToken, authUrl = :authUrl, websocketUrl = :websocketUrl, httpApiUrl = :httpApiUrl, httpApiKey = :httpApiKey, mode = :mode, allowUntrustedCerts = :allowUntrustedCerts, secretKey = :secretKey WHERE _id = :_id"
             let arguments: [String: Any] = [
                 "_id": appConfig._id,
                 "name": appConfig.name,
@@ -174,6 +175,7 @@ actor DatabaseRepository {
                 "httpApiKey": appConfig.httpApiKey,
                 "mode": appConfig.mode,
                 "allowUntrustedCerts": appConfig.allowUntrustedCerts,
+                "secretKey": appConfig.secretKey,
             ]
             try await ditto.store.execute(
                 query: query,

--- a/SwiftUI/Edge Debug Helper/Models/AuthMode.swift
+++ b/SwiftUI/Edge Debug Helper/Models/AuthMode.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+enum AuthMode: String, CaseIterable, Codable {
+    case onlinePlayground = "onlineplayground"
+    case offlinePlayground = "offlineplayground"
+    case sharedKey = "sharedkey"
+    
+    var displayName: String {
+        switch self {
+        case .onlinePlayground:
+            return "Online Playground"
+        case .offlinePlayground:
+            return "Offline Playground"
+        case .sharedKey:
+            return "Shared Key"
+        }
+    }
+    
+    static var `default`: AuthMode {
+        return .onlinePlayground
+    }
+}

--- a/SwiftUI/Edge Debug Helper/Models/DittoAppConfig.swift
+++ b/SwiftUI/Edge Debug Helper/Models/DittoAppConfig.swift
@@ -10,8 +10,9 @@ class DittoAppConfig: Decodable {
     var websocketUrl: String
     var httpApiUrl: String
     var httpApiKey: String
-    var mode: String
+    var mode: AuthMode
     var allowUntrustedCerts: Bool
+    var secretKey: String
 
     init(
         _ _id: String,
@@ -22,8 +23,9 @@ class DittoAppConfig: Decodable {
         websocketUrl: String,
         httpApiUrl: String,
         httpApiKey: String,
-        mode: String = "online",
-        allowUntrustedCerts: Bool = false
+        mode: AuthMode = .onlinePlayground,
+        allowUntrustedCerts: Bool = false,
+        secretKey: String = ""
     ) {
 
         self._id = _id
@@ -36,6 +38,7 @@ class DittoAppConfig: Decodable {
         self.httpApiKey = httpApiKey
         self.mode = mode
         self.allowUntrustedCerts = allowUntrustedCerts
+        self.secretKey = secretKey
     }
     enum CodingKeys: String, CodingKey {
         case _id
@@ -48,6 +51,7 @@ class DittoAppConfig: Decodable {
         case httpApiKey
         case mode
         case allowUntrustedCerts
+        case secretKey
     }
 
     required init(from decoder: Decoder) throws {
@@ -60,8 +64,26 @@ class DittoAppConfig: Decodable {
         websocketUrl = try container.decode(String.self, forKey: .websocketUrl)
         httpApiUrl = try container.decode(String.self, forKey: .httpApiUrl)
         httpApiKey = try container.decode(String.self, forKey: .httpApiKey)
-        mode = try container.decode(String.self, forKey: .mode)
+        // Handle both legacy string values and new enum values
+        if let modeEnum = try? container.decode(AuthMode.self, forKey: .mode) {
+            mode = modeEnum
+        } else if let modeString = try? container.decode(String.self, forKey: .mode) {
+            // Map legacy string values to enum cases
+            switch modeString {
+            case "online", "onlineplayground":
+                mode = .onlinePlayground
+            case "offline", "sharedkey":
+                mode = .sharedKey
+            case "offlineplayground":
+                mode = .offlinePlayground
+            default:
+                mode = .onlinePlayground
+            }
+        } else {
+            mode = .onlinePlayground
+        }
         allowUntrustedCerts = try container.decodeIfPresent(Bool.self, forKey: .allowUntrustedCerts) ?? false
+        secretKey = try container.decodeIfPresent(String.self, forKey: .secretKey) ?? ""
     }
 }
 
@@ -76,8 +98,9 @@ extension DittoAppConfig {
             websocketUrl: "",
             httpApiUrl: "",
             httpApiKey: "",
-            mode: "online",
-            allowUntrustedCerts: false
+            mode: .onlinePlayground,
+            allowUntrustedCerts: false,
+            secretKey: ""
         )
     }
 }


### PR DESCRIPTION
This pull request introduces support for SharedKey authentication and renames previous 'Online' and 'Offline' authentication modes to 'Online Playground' and 'Offline Playground', respectively.

## Demo of changes: 
https://www.loom.com/share/b328d708eadd41baaf5510c8d9571d3a?sid=86c35b98-0577-4d64-89e5-a5cf56a1db33